### PR TITLE
Made xcodePreferences.js compatible with Cordova v7

### DIFF
--- a/hooks/lib/ios/xcodePreferences.js
+++ b/hooks/lib/ios/xcodePreferences.js
@@ -142,10 +142,18 @@ function loadProjectFile() {
     projectFile = platform_ios.parseProjectFile(iosPlatformPath());
   } catch (e) {
     // let's try cordova 5.0 structure
-    platform_ios = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
-    projectFile = platform_ios.parseProjectFile(iosPlatformPath());
+    try {
+      platform_ios = context.requireCordovaModule('cordova-lib/src/plugman/platforms/ios');
+      projectFile = platform_ios.parseProjectFile(iosPlatformPath());
+    } catch(e) {
+      // try cordova 7.0 structure
+      var iosPlatformApi = require(path.join(iosPlatformPath(), '/cordova/Api'));
+      var projectFileApi = require(path.join(iosPlatformPath(), '/cordova/lib/projectFile.js'));
+      var locations = (new iosPlatformApi()).locations;
+      projectFile = projectFileApi.parse(locations);      
+    }
   }
-
+  
   return projectFile;
 }
 


### PR DESCRIPTION
This fixes a fatal error when preparing for the ios platform with Cordova v7